### PR TITLE
Removing Favorite Locations

### DIFF
--- a/routes/api/v1/favorite_locations.js
+++ b/routes/api/v1/favorite_locations.js
@@ -22,4 +22,21 @@ router.post("/", async (req, res, next) => {
   }
 })
 
+
+router.get("/", async (req, res, next) => {
+  try {
+    const user = await User.findOne({ where: {api_key: req.body.api_key}})
+    if(!user) {
+      res.status(401).send(JSON.stringify('Unauthorized'))
+    } else {
+      const favorites = await Favorite.find({where: {UserId: user.id}})
+
+      
+    }
+  }
+  catch {
+    res.status(500).send({ error })
+  }
+})
+
 module.exports = router;

--- a/routes/api/v1/favorite_locations.js
+++ b/routes/api/v1/favorite_locations.js
@@ -3,25 +3,25 @@ var router = express.Router();
 var User = require('../../../models').User;
 var Location = require('../../../models').Location;
 var Favorite = require('../../../models').Favorite;
+pry = require('pryjs');
 
 router.post("/", async (req, res, next) => {
   try {
-    const location = req.body.location;
     const user = await User.findOne({ where: {api_key: req.body.api_key}})
     if(!user) {
       res.status(401).send(JSON.stringify('Unauthorized'))
     } else {
+      const location = req.body.location;
       const foundLocation = await Location.findOrCreate({where: {name: location}})
       const favorite = await Favorite.findOrCreate({where: {UserId: user.id, LocationId: foundLocation[0].id}})
       const message = {'message': `${location} has been added to your favorites`}
       res.status(200).send(JSON.stringify(message))
     }
   }
-  catch {
+  catch(error) {
     res.status(500).send({ error })
   }
 })
-
 
 router.get("/", async (req, res, next) => {
   try {
@@ -30,11 +30,28 @@ router.get("/", async (req, res, next) => {
       res.status(401).send(JSON.stringify('Unauthorized'))
     } else {
       const favorites = await Favorite.find({where: {UserId: user.id}})
-
-      
+// Do weather stuff
+// res.send
     }
   }
-  catch {
+  catch(error) {
+    res.status(500).send({ error })
+  }
+})
+
+router.delete("/", async (req, res, next) => {
+  try {
+    const user = await User.findOne({ where: {api_key: req.body.api_key}})
+    if(!user) {
+      res.status(401).send(JSON.stringify('Unauthorized'))
+    } else {
+      const location = req.body.location;
+      const foundLocation = await Location.findOne({where: {name: location}})
+      const favorite = await Favorite.destroy({where: {UserId: user.id, LocationId: foundLocation.id}})
+      res.status(204).send()
+    }
+  }
+  catch(error) {
     res.status(500).send({ error })
   }
 })

--- a/routes/api/v1/favorite_locations.js
+++ b/routes/api/v1/favorite_locations.js
@@ -4,32 +4,22 @@ var User = require('../../../models').User;
 var Location = require('../../../models').Location;
 var Favorite = require('../../../models').Favorite;
 
-router.post("/", function(req, res, next) {
-  var location = req.body.location;
-  return User.findOne({ where: {api_key: req.body.api_key}})
-    .then(user => {
-      if(!user) {
-        res.status(401).send(JSON.stringify('Unauthorized'))
-      } else {
-        return Location.findOrCreate({where: {name: location}})
-          .then(foundLocation => {
-            return Favorite.findOrCreate({where: {UserId: user.id, LocationId: foundLocation[0].id}})
-            .then(favorite => {
-              var message = {'message': `${location} has been added to your favorites`}
-              res.status(200).send(JSON.stringify(message))
-            })
-            .catch(error => {
-              res.status(500).send({ error })
-            })
-          })
-          .catch(error => {
-            res.status(500).send({ error })
-          })
-      }
-    })
-  .catch(error => {
+router.post("/", async (req, res, next) => {
+  try {
+    const location = req.body.location;
+    const user = await User.findOne({ where: {api_key: req.body.api_key}})
+    if(!user) {
+      res.status(401).send(JSON.stringify('Unauthorized'))
+    } else {
+      const foundLocation = await Location.findOrCreate({where: {name: location}})
+      const favorite = await Favorite.findOrCreate({where: {UserId: user.id, LocationId: foundLocation[0].id}})
+      const message = {'message': `${location} has been added to your favorites`}
+      res.status(200).send(JSON.stringify(message))
+    }
+  }
+  catch {
     res.status(500).send({ error })
-  })
-});
+  }
+})
 
 module.exports = router;

--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -19,7 +19,7 @@ router.get("/", async (req, res, next) => {
       const long = coordinates["lng"];
       const forecastResponse = await fetch(`https://api.darksky.net/forecast/${key}/${lat},${long}?exclude=minutely`)
       const weatherResponse = await forecastResponse.json();
-      res.send(JSON.stringify(parsedWeather(address, weatherResponse)));
+      res.status(200).send(JSON.stringify(parsedWeather(address, weatherResponse)));
     }
   }
   catch(error) {


### PR DESCRIPTION
### Removing Favorite Locations
This pull request adds the following functionality. 
An additional user story has been created for testing and attempting to delete a favorite city that is not actually favorited.

### User Story
When a user sends a `DELETE` request to `/api/v1/favorites`, in the format of JSON, with the following in the `body`:
```
body:

{
  "location": "Denver, CO",
  "api_key": "jgn983hy48thw9begh98h4539h4"
}
```
The following response is received:
```
status: 204
```
- [x] If no API key is provided it returns 401 (Unauthorized)
- [x] If an incorrect API key is provided it returns 401 (Unauthorized)