### PR TITLE
Listing Favorite Locations - 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ DELETE /api/v1/favorites, body: {"location": "Denver, CO", "api_key": "<returned
 ### Author
 [Mackenzie Frey](https://github.com/Mackenzie-Frey)
 
-### Contributors
+### Collaborators
 * [Dione Wilson](https://github.com/dionew1)
 * [Cory Westerfield](https://github.com/corywest)
 * [Hillary Stewart](https://github.com/hillstew)

--- a/routes/api/v1/favorite_locations.js
+++ b/routes/api/v1/favorite_locations.js
@@ -1,5 +1,6 @@
 var express = require("express");
 var router = express.Router();
+var fetch = require("node-fetch");
 var User = require('../../../models').User;
 var Location = require('../../../models').Location;
 var Favorite = require('../../../models').Favorite;
@@ -29,10 +30,23 @@ router.get("/", async (req, res, next) => {
     if(!user) {
       res.status(401).send(JSON.stringify('Unauthorized'))
     } else {
-      eval(pry.it)
       const favorites = await Favorite.findAll({where: {UserId: user.id}})
-// Do weather stuff
-      res.status(200).send()
+      const weatherResponse = await Promise.all(favorites.map(async favorite => {
+        const location = await Location.findOne({where: {id: favorite.LocationId}})
+        const coordResponse = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?address=${location.name}&key=${process.env.google_key}`)
+        const geoResponse = await coordResponse.json();
+        const coordinates = geoResponse["results"][0]["geometry"]["location"];
+        const key = process.env.dark_sky_key;
+        const lat = coordinates["lat"];
+        const long = coordinates["lng"];
+        const forecastResponse = await fetch(`https://api.darksky.net/forecast/${key}/${lat},${long}?exclude=minutely`)
+        const weather = await forecastResponse.json();
+        return {
+          "location": location.name,
+          "current_weather": weather.currently
+        }
+      }))
+      res.status(200).send(JSON.stringify(weatherResponse));
     }
   }
   catch(error) {

--- a/routes/api/v1/favorite_locations.js
+++ b/routes/api/v1/favorite_locations.js
@@ -29,9 +29,10 @@ router.get("/", async (req, res, next) => {
     if(!user) {
       res.status(401).send(JSON.stringify('Unauthorized'))
     } else {
-      const favorites = await Favorite.find({where: {UserId: user.id}})
+      eval(pry.it)
+      const favorites = await Favorite.findAll({where: {UserId: user.id}})
 // Do weather stuff
-// res.send
+      res.status(200).send()
     }
   }
   catch(error) {


### PR DESCRIPTION
### Listing Favorite Locations
This pull request implements the following functionality. An additional card has been made to integrate testing.

### User Story
When a user sends a `GET` request to `/api/v1/favorites`, in the format of JSON, with the following in the `body`:
```
body:

{
  "api_key": "jgn983hy48thw9begh98h4539h4"
}
```
They receive the following response:
```
status: 200
body:
[
  {
    "location": "Denver, CO",
    "current_weather": {
      "summary": "Overcast",
      "icon": "cloudy",
      "precipIntensity": 0,
      "precipProbability": 0,
      "temperature": 54.91,
      "humidity": 0.65,
      "pressure": 1020.51,
      "windSpeed": 11.91,
      "windGust": 23.39,
      "windBearing": 294,
      "cloudCover": 1,
      "visibility": 9.12,
    },
    "location": "Golden, CO",
    "current_weather": {
      "summary": "Sunny",
      "icon": "sunny",
      "precipIntensity": 0,
      "precipProbability": 0,
      "temperature": 71.00,
      "humidity": 0.50,
      "pressure": 1015.10,
      "windSpeed": 10.16,
      "windGust": 13.40,
      "windBearing": 200,
      "cloudCover": 0,
      "visibility": 8.11,
    }
  }
]
```

@hillstew Thoughts? I'm getting this error related to line 33 " SyntaxError: await is only valid in async function"

- [x] If no API key is provided it returns 401 (Unauthorized)
- [x] If an incorrect API key is provided it returns 401 (Unauthorized)